### PR TITLE
Remove unused flag API helper

### DIFF
--- a/src/api/flags.ts
+++ b/src/api/flags.ts
@@ -1,8 +1,0 @@
-import fs from 'fs';
-import path from 'path';
-
-export const getFlags = () => {
-  const flagsDir = path.join(process.cwd(), 'public/flags');
-  const files = fs.readdirSync(flagsDir);
-  return files.filter(file => file.endsWith('.png'));
-}; 


### PR DESCRIPTION
## Summary
- remove obsolete `src/api/flags.ts`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68408f05f12483319ffded56160ee981